### PR TITLE
Handle sigpipe

### DIFF
--- a/gh-repo-list
+++ b/gh-repo-list
@@ -2,7 +2,9 @@
 """List all repositories."""
 import argparse
 import json
+import os
 import subprocess
+import sys
 from dataclasses import dataclass
 from pprint import pprint
 # Use `typing.*` instead of `collections.abc` to support older Python versions.
@@ -20,8 +22,15 @@ def main():
     commands = list_commands()
     command = commands[args.type]
 
-    for output in command():
-        print(output)
+    try:
+        for output in command():
+            print(output)
+    except BrokenPipeError:
+        # see docs here:
+        # https://docs.python.org/3/library/signal.html#note-on-sigpipe
+        devnull = os.open(os.devnull, os.O_WRONLY)
+        os.dup2(devnull, sys.stdout.fileno())
+        sys.exit(1)  # Python exits with error code 1 on EPIPE
 
 
 @dataclass


### PR DESCRIPTION
Thanks for making this script, it's really handy to get my starred repos on the command line. I did have one issue, which this PR addresses.

Before this PR, if you pipe to `head` or something you'll get a traceback about SIGPIPE. This PR follows the example recommended in the official Python docs for handling SIGPIPE cleanly.